### PR TITLE
add vars names convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,18 @@
 
 Oficial Documentation of Elixir
 https://elixir-lang.org/
+
+## Variables Names
+
+In Elixir, a variable name always starts with a lowercase alphabetic character or an
+underscore. After that, any combination of alphanumerics and underscores is allowed.
+The prevalent convention is to use only lowercase ASCII letters, digits, and underscores:
+* valid_variable_name
+* also_valid_1
+* validButNotRecommended
+* NotValid
+
+Variable names can also end with the question mark (?) or exclamation mark (!)
+characters:
+* valid_name?
+* also_ok!


### PR DESCRIPTION
Adiciona as informações de convenção de variavel ao readme:

## Variables Names

In Elixir, a variable name always starts with a lowercase alphabetic character or an
underscore. After that, any combination of alphanumerics and underscores is allowed.
The prevalent convention is to use only lowercase ASCII letters, digits, and underscores:
* valid_variable_name
* also_valid_1
* validButNotRecommended
* NotValid

Variable names can also end with the question mark (?) or exclamation mark (!)
characters:
* valid_name?
* also_ok!